### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+    open-pull-requests-limit: 10
+    groups:
+      composer-version-updates:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      composer-security-updates:
+        patterns:
+          - "*"
+        applies-to: "security-updates"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+    open-pull-requests-limit: 10
+    groups:
+      actions-version-updates:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      actions-security-updates:
+        patterns:
+          - "*"
+        applies-to: "security-updates"


### PR DESCRIPTION
Adds a `.github/dependabot.yml` to enable automated weekly dependency updates for `composer` and `github-actions`, grouped into version and security update PRs. Matches the convention used across other zitadel example repositories.