### PR TITLE
fix: add fallback controller for /login_check route

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -5,3 +5,4 @@ controllers:
     type: attribute
 login_check:
     path: /login_check
+    controller: App\Controller\LoginController::loginCheck

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -23,4 +23,9 @@ class LoginController extends AbstractController
         // Redirect to authorization @ OIDC provider
         return $oidcClient->generateAuthorizationRedirect(scopes: ZitadelUserProvider::SCOPES);
     }
+
+    public function loginCheck(): RedirectResponse
+    {
+        return $this->redirectToRoute('login');
+    }
 }


### PR DESCRIPTION
The /login_check route had no controller, causing a 404 when the OIDC authenticator didn't intercept (e.g. error redirects from the provider or direct navigation).

Fixes #15